### PR TITLE
Modernize JPA queries and fix compiler warnings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,319 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a Java 21 educational codebase containing algorithm practice problems, coding challenges, and design pattern implementations. The main module `MCalc` serves as a Maven project with integrated PostgreSQL/Hibernate functionality and Kafka messaging capabilities.
+
+## Build System & Commands
+
+**Maven Commands (run from `/MCalc` directory):**
+- `mvn clean compile` - Clean and compile the project
+- `mvn test` - Run all tests using JUnit 5
+- `mvn clean test` - Clean, compile, and run tests
+- `mvn clean package` - Build JAR package
+
+**Testing:**
+- Uses JUnit 5 (Jupiter) for unit testing
+- Test files follow naming convention: `*Test.java`
+- Tests are located in `src/test/java` with same package structure as main code
+
+**Database:**
+- PostgreSQL database configured via `hibernate.cfg.xml`
+- Database name: `demo`, user: `jupiter`
+- Run `docker-compose up` from `/docker` directory to start Kafka cluster
+- Hibernate auto-update enabled (`hibernate.hbm2ddl.auto=update`)
+
+## Code Architecture
+
+**Package Structure:**
+- `com.pluralsight.calcengine` - Core calculator and basic Java examples
+- `com.playground` - Advanced implementations and design patterns
+- `com.playground.PostgreSQL` - Hibernate/JPA entities and repositories
+- `com.DailyByte`, `com.CoderPad`, `kata.kyu*` - Algorithm challenges by source
+
+**Key Patterns:**
+- **Repository Pattern**: `OrderRepository`, `CustomerRepository` with Criteria API queries
+- **Entity Mapping**: JPA entities with proper relationships and soft delete support
+- **Hibernate Integration**: `HibernateUtil` for SessionFactory management
+- **Decorator Pattern**: Coffee/MyList implementations in `playground.Patterns`
+- **Observer Pattern**: Stock market implementation
+- **Visitor Pattern**: Payment processing implementations
+
+**Entity Relationships:**
+- `Customer` 1:N `Order` 1:N `OrderItem` N:1 `Product`
+- All entities extend `AuditableEntity` with created/modified timestamps
+- Soft delete implemented with `@SQLDelete` and `deleted` boolean field
+
+**Testing Strategy:**
+- Repository classes have corresponding integration tests
+- Hibernate SessionFactory properly configured for test environment
+- Each algorithm/challenge has dedicated test class
+
+## Key Dependencies
+
+- **Java 21** with Maven compiler plugin 3.14.0
+- **Hibernate 6.5.3** with PostgreSQL driver 42.7.5
+- **JUnit 5.10.5** for testing
+- **Lombok 1.18.34** for code generation
+- **Log4j 2.19.0** for logging
+- **Kafka 3.8.1** and **MongoDB 5.1.4** drivers
+
+## Development Notes
+
+- All entities use Lombok annotations (`@Getter`, `@Setter`, `@ToString`)
+- Hibernate proxy-aware `equals()` and `hashCode()` implementations
+- Criteria API used extensively for type-safe queries
+- Transaction management with proper rollback handling in repositories
+
+---
+
+# Claude Code Operating Instructions
+
+## Code Change Protocol
+
+When proposing or making code changes, follow this process:
+
+### 1. Analysis Phase
+- **Identify the Issue**: Clearly explain what problem you're solving
+- **Root Cause**: Explain why the issue exists 
+- **Impact Assessment**: Describe the consequences of not fixing it
+
+### 2. Solution Proposal Phase
+- **Proposed Solution**: Describe your intended fix in detail
+- **Alternative Approaches**: Mention other solutions you considered and why you chose this one
+- **Trade-offs**: Explain any downsides or limitations of your approach
+- **Code Example**: Show the specific before/after code when possible
+
+### 3. User Approval Phase
+- **Wait for Confirmation**: Do not make changes until the user approves
+- **Answer Follow-up Questions**: Be prepared to explain technical details, provide more context, or discuss alternatives
+- **Modify Approach**: Be flexible if the user suggests a different solution
+
+### 4. Implementation Phase
+- **Make the Change**: Implement the approved solution
+- **Verify the Fix**: Test that the change works as expected
+- **Document Impact**: Briefly summarize what was changed
+
+## Code Quality Standards
+
+### Warning and Error Handling
+- **Explain Each Warning**: For compiler warnings, explain what causes them and why they matter
+- **Justify Suppressions**: If using `@SuppressWarnings`, explain why suppression is appropriate vs fixing the root cause
+- **Security Implications**: Always consider if a warning indicates a potential security issue
+
+### Refactoring Guidelines
+- **Minimal Scope**: Make the smallest change that solves the problem
+- **Backward Compatibility**: Preserve existing functionality unless explicitly asked to change it
+- **Educational Value**: Since this is a learning codebase, prefer solutions that demonstrate best practices
+
+### Code Examples
+When explaining changes, provide:
+```java
+// Before (problematic code)
+PriorityQueue heap = new PriorityQueue(); // Raw type warning
+
+// After (fixed code)  
+PriorityQueue<Integer> heap = new PriorityQueue<>(); // Type-safe generics
+
+// Why: Raw types bypass compile-time type checking, risking ClassCastException at runtime
+```
+
+## Communication Style
+
+### Technical Explanations
+- **Start Simple**: Begin with a high-level explanation
+- **Provide Details**: Offer technical depth when requested
+- **Use Examples**: Include concrete code examples
+- **Explain Consequences**: Describe what happens if the issue isn't fixed
+
+### Decision Making
+- **Present Options**: When multiple solutions exist, explain the pros/cons of each
+- **Recommend Best Practice**: Suggest the approach that follows Java/industry standards
+- **Respect Preferences**: Defer to user's architectural decisions and coding style
+
+### Follow-up Support
+- **Answer Questions**: Be prepared to explain any aspect of your proposed changes
+- **Provide Context**: Explain how changes fit into the larger codebase architecture
+- **Offer Alternatives**: If the user doesn't like your approach, suggest other options
+
+## Example Workflow
+
+```
+1. Claude identifies issue: "There's a deprecation warning in OrderRepository.java line 236"
+
+2. Claude explains: "The multiselect() method is deprecated in JPA 3.2 because..."
+
+3. Claude proposes: "I can fix this by either: A) Suppressing the warning, or B) Refactoring to use cb.tuple(). Here's why I recommend option A..."
+
+4. User responds: "Why not option B? Show me what that would look like."
+
+5. Claude provides detailed comparison and code examples
+
+6. User approves: "Go with option A for now"
+
+7. Claude implements and confirms the fix works
+```
+
+This ensures you understand not just what to change, but why the change is beneficial and have approved the approach before implementation.
+
+## Advanced Best Practices
+
+### Object-Oriented Design Principles (SOLID)
+
+#### Single Responsibility Principle (SRP)
+- **Class Purpose**: Ensure each class has one clear, focused responsibility
+- **Method Scope**: Functions should do one thing well
+- **Refactoring Trigger**: If explaining what a class does requires "and", consider splitting it
+
+#### Open/Closed Principle (OCP)
+- **Extension Points**: Design for extension through interfaces and inheritance
+- **Modification Risk**: Prefer adding new code over modifying existing stable code
+- **Strategy Pattern**: Use for algorithms that may change (like payment processing)
+
+#### Liskov Substitution Principle (LSP)
+- **Inheritance Contracts**: Subclasses must be substitutable for their base classes
+- **Behavioral Compatibility**: Override methods should strengthen, not weaken, contracts
+- **Interface Segregation**: Don't force implementers to depend on unused methods
+
+#### Interface Segregation Principle (ISP)
+- **Focused Interfaces**: Create small, focused interfaces rather than large monolithic ones
+- **Client Specificity**: Interfaces should serve specific client needs
+- **Default Methods**: Use Java 8+ default methods judiciously
+
+#### Dependency Inversion Principle (DIP)
+- **Abstract Dependencies**: Depend on abstractions, not concrete implementations
+- **Injection Patterns**: Prefer constructor injection over field injection
+- **Repository Pattern**: Abstract data access behind interfaces
+
+### Performance & Security
+
+#### Performance Impact Analysis
+- **Big O Complexity**: Explain algorithmic complexity changes
+- **Database Queries**: Analyze N+1 query problems and query optimization
+- **Memory Usage**: Consider object creation, collections sizing, and garbage collection
+- **Lazy Loading**: Evaluate Hibernate lazy vs eager loading implications
+
+#### Security Review
+- **Input Validation**: Ensure all user inputs are properly validated and sanitized
+- **SQL Injection**: Use parameterized queries and avoid string concatenation
+- **Data Exposure**: Review what data is exposed in logs, error messages, and APIs
+- **Access Control**: Verify authorization checks are in place where needed
+- **Sensitive Data**: Never log passwords, tokens, or other secrets
+
+#### Resource Management
+- **Try-with-resources**: Use for database connections, file handles, streams
+- **Connection Pooling**: Ensure proper Hibernate session management
+- **Memory Leaks**: Watch for static collections, listeners not removed, unclosed resources
+
+### Testing Strategy
+
+#### Test Impact Assessment
+- **Unit Test Coverage**: Identify which tests need updates after changes
+- **Integration Tests**: Especially critical for Hibernate/JPA repository changes
+- **Mock Boundaries**: Determine what should be mocked vs tested with real dependencies
+- **Test Data Management**: Consider test database state and cleanup
+
+#### New Test Requirements
+- **Boundary Conditions**: Test edge cases, null inputs, empty collections
+- **Error Scenarios**: Test exception handling and error conditions
+- **Performance Tests**: For changes that might affect performance
+- **Security Tests**: For authentication, authorization, and input validation changes
+
+#### Integration Test Considerations
+- **Database Transactions**: Ensure proper rollback in test scenarios
+- **Test Isolation**: Each test should be independent and repeatable
+- **Environment Configuration**: Test with realistic data volumes when relevant
+
+### Documentation & Maintainability
+
+#### Code Comments Policy
+- **When to Comment**: Complex business logic, non-obvious algorithms, workarounds
+- **When NOT to Comment**: Don't comment what the code obviously does
+- **Javadoc Standards**: Use for public APIs, include @param, @return, @throws
+- **TODO/FIXME**: Include tickets or deadlines for temporary solutions
+
+#### Breaking Changes
+- **API Compatibility**: Flag any changes to public method signatures
+- **Database Schema**: Highlight any entity or migration impacts
+- **Configuration Changes**: Note any required updates to properties files
+- **Deprecation Strategy**: Use @Deprecated with replacement guidance
+
+#### Future-Proofing
+- **Java Version Compatibility**: Consider impact of language feature usage
+- **Dependency Updates**: Design to be resilient to minor version updates
+- **Extensibility**: Leave extension points for likely future requirements
+
+### Dependency Management
+
+#### Version Compatibility
+- **Semantic Versioning**: Understand major/minor/patch version implications
+- **Spring Boot/Hibernate**: Be aware of compatibility matrices
+- **Java 21 Features**: Leverage appropriate modern language features
+
+#### Transitive Dependencies
+- **Dependency Conflicts**: Watch for version conflicts in Maven
+- **Classpath Issues**: Consider library conflicts and exclusions
+- **Security Vulnerabilities**: Be aware of vulnerable dependency versions
+
+#### Build Tool Integration
+- **Maven Lifecycle**: Ensure changes work with all relevant goals
+- **IDE Compatibility**: Consider IntelliJ IDEA and VS Code integration
+- **CI/CD Pipeline**: Think about automated build and deployment impacts
+
+### Educational Considerations
+
+#### Learning Objectives
+- **Design Patterns**: Demonstrate Gang of Four patterns appropriately
+- **Best Practices**: Show modern Java idioms and conventions
+- **Architecture Concepts**: Illustrate layered architecture, separation of concerns
+- **Enterprise Patterns**: Repository, Service Layer, Data Transfer Objects
+
+#### Progressive Complexity
+- **Scaffold Learning**: Start with simple implementations, add complexity gradually
+- **Multiple Approaches**: Show different ways to solve similar problems
+- **Real-World Examples**: Use patterns that mirror production scenarios
+- **Avoid Over-Engineering**: Don't add complexity just to show off features
+
+#### Code Examples Across Files
+- **Consistency**: Use similar patterns for similar problems
+- **Variation**: Show different approaches where educationally valuable
+- **Evolution**: Demonstrate how simple code can be refactored to more sophisticated solutions
+
+### Error Handling & Debugging
+
+#### Error Message Quality
+- **User-Friendly Messages**: Clear, actionable error descriptions
+- **Developer Context**: Include enough detail for debugging
+- **Internationalization**: Consider message externalization for larger applications
+- **Log Levels**: Use appropriate levels (ERROR, WARN, INFO, DEBUG)
+
+#### Debugging Support
+- **Meaningful Variable Names**: Aid in debugger inspection
+- **Intermediate Variables**: Sometimes break complex expressions for clarity
+- **Logging Strategy**: Log important state changes and decision points
+- **Stack Trace Preservation**: Don't swallow exceptions without proper handling
+
+#### Rollback Strategy
+- **Database Migrations**: Plan for rollback scenarios
+- **Configuration Changes**: Document how to revert settings
+- **Feature Flags**: Consider toggles for larger changes
+- **Backup Plans**: Know how to quickly revert problematic changes
+
+### Code Review Guidelines
+
+#### Before Proposing Changes
+- **Self-Review**: Walk through the change as if reviewing someone else's code
+- **Testing**: Verify all relevant test scenarios pass
+- **Documentation**: Update any affected documentation
+- **Performance**: Consider the performance implications
+
+#### Review Criteria
+- **Functionality**: Does it solve the intended problem?
+- **Design**: Does it follow SOLID principles and good OOP design?
+- **Security**: Are there any security implications?
+- **Performance**: Will it perform acceptably under load?
+- **Maintainability**: Will future developers understand and modify this easily?
+
+This comprehensive approach ensures code changes are not only functional but also maintainable, secure, and educational.

--- a/MCalc/pom.xml
+++ b/MCalc/pom.xml
@@ -120,11 +120,20 @@
                 <configuration>
                     <source>21</source>
                     <target>21</target>
+                    <compilerArgs>
+                        <arg>-Xlint:deprecation</arg>
+                        <arg>-Xlint:unchecked</arg>
+                    </compilerArgs>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>org.hibernate.orm</groupId>
                             <artifactId>hibernate-jpamodelgen</artifactId>
                             <version>6.6.1.Final</version>
+                        </path>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>1.18.34</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>
@@ -133,6 +142,23 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.5.2</version>
+                <configuration>
+                    <includes>
+                        <include>**/*Test.java</include>
+                    </includes>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-engine</artifactId>
+                        <version>5.10.5</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.junit.platform</groupId>
+                        <artifactId>junit-platform-surefire-provider</artifactId>
+                        <version>1.3.2</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/MCalc/src/main/java/com/DailyByte/ConsecutiveValueGroups/ConsecutiveValueGroups.java
+++ b/MCalc/src/main/java/com/DailyByte/ConsecutiveValueGroups/ConsecutiveValueGroups.java
@@ -70,7 +70,7 @@ public class ConsecutiveValueGroups {
 
 
     public boolean solution (int[] nums, int k) {
-        PriorityQueue<Integer> heap = new PriorityQueue();
+        PriorityQueue<Integer> heap = new PriorityQueue<>();
         for (int num: nums){
             heap.add(num);
         }

--- a/MCalc/src/main/java/com/linkedinlearning/JavaArrays/CustomArrayList.java
+++ b/MCalc/src/main/java/com/linkedinlearning/JavaArrays/CustomArrayList.java
@@ -17,7 +17,9 @@ public class CustomArrayList<D> {
             System.out.println("Invalid index");
             return null;
         }
-            return (D) elements[i];
+            @SuppressWarnings("unchecked")
+            D result = (D) elements[i];
+            return result;
     }
 
     public void add (D item) {

--- a/MCalc/src/main/java/com/playground/Inheritance/Animals/Dog.java
+++ b/MCalc/src/main/java/com/playground/Inheritance/Animals/Dog.java
@@ -8,7 +8,7 @@ import java.util.logging.Logger;
 @Getter @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 @ToString
 public class Dog extends Animal {
 

--- a/MCalc/src/main/java/com/playground/MyList/MyListError/MyListError.java
+++ b/MCalc/src/main/java/com/playground/MyList/MyListError/MyListError.java
@@ -29,6 +29,7 @@ public class MyListError<T> {
         arr = newArr;
     }
 
+    @SuppressWarnings("unchecked")
     public boolean addAll(T... items) {
         boolean result = true;
         for (T item : items) {

--- a/MCalc/src/main/java/com/playground/MyList/MyListError/MyListErrorWithCounter.java
+++ b/MCalc/src/main/java/com/playground/MyList/MyListError/MyListErrorWithCounter.java
@@ -15,7 +15,8 @@ public class MyListErrorWithCounter<T> extends MyListError<T> {
     }
 
     @Override
-    public final boolean addAll(T... items) {
+    @SuppressWarnings("unchecked")
+    public boolean addAll(T... items) {
         return super.addAll(items);
     }
 

--- a/MCalc/src/main/java/com/pluralsight/calcengine/HashMapExample.java
+++ b/MCalc/src/main/java/com/pluralsight/calcengine/HashMapExample.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 
 public class HashMapExample {
 
-    HashMap<Integer, Integer> hashMap = new HashMap();
+    HashMap<Integer, Integer> hashMap = new HashMap<>();
 
     public HashMapExample() {
         this.hashMap.put(0,0);

--- a/MCalc/src/test/java/com/playground/PostgreSQL/repository/OrderRepositoryTest.java
+++ b/MCalc/src/test/java/com/playground/PostgreSQL/repository/OrderRepositoryTest.java
@@ -4,6 +4,7 @@ package com.playground.PostgreSQL.repository;
 import com.playground.PostgreSQL.entities.Customer;
 import com.playground.PostgreSQL.entities.Order;
 import com.playground.PostgreSQL.utilities.HibernateUtil;
+import jakarta.persistence.Tuple;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
@@ -282,18 +283,18 @@ class OrderRepositoryTest {
     @Test
     @org.junit.jupiter.api.Order(8)
     void testCountOrdersByCustomer() {
-        // Get order counts by customer
-        List<Object[]> orderCounts = orderRepository.countOrdersByCustomer();
+        // Get order counts by customer using modern Tuple approach
+        List<Tuple> orderCounts = orderRepository.countOrdersByCustomer();
 
         // Verify we have results
         assertFalse(orderCounts.isEmpty(), "Should have order counts");
 
         // Find our test customers in the results
-        Object[] customer1Result = null;
-        Object[] customer2Result = null;
+        Tuple customer1Result = null;
+        Tuple customer2Result = null;
 
-        for (Object[] result : orderCounts) {
-            Customer customer = (Customer) result[0];
+        for (Tuple result : orderCounts) {
+            Customer customer = result.get(0, Customer.class);  // Type-safe access
             if (customer.getId().equals(testCustomer1.getId())) {
                 customer1Result = result;
             } else if (customer.getId().equals(testCustomer2.getId())) {
@@ -305,8 +306,9 @@ class OrderRepositoryTest {
         assertNotNull(customer1Result, "Should find testCustomer1 in results");
         assertNotNull(customer2Result, "Should find testCustomer2 in results");
 
-        assertEquals(2L, customer1Result[1], "Customer 1 should have 2 orders");
-        assertEquals(1L, customer2Result[1], "Customer 2 should have 1 order");
+        // Type-safe access to count values
+        assertEquals(2L, customer1Result.get(1, Long.class), "Customer 1 should have 2 orders");
+        assertEquals(1L, customer2Result.get(1, Long.class), "Customer 2 should have 1 order");
     }
 
     @Test


### PR DESCRIPTION
- Replace deprecated multiselect() with cb.tuple() for type-safe queries
- Fix all unchecked and deprecation warnings across codebase
- Add comprehensive Claude Code operating instructions in CLAUDE.md
- Configure Maven for detailed compiler warnings and JUnit 5 support

Technical improvements:
• OrderRepository: Migrate from Object[] to Tuple return type • Lombok: Fix equals/hashCode inheritance warnings • Generics: Replace raw types with parameterized types • Varargs: Add appropriate @SuppressWarnings annotations • Maven: Add Lombok annotation processor and compiler args

🤖 Generated with [Claude Code](https://claude.ai/code)